### PR TITLE
Made the header selectors regular expressions

### DIFF
--- a/Pages/AllPageTree.cs
+++ b/Pages/AllPageTree.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml.Linq;
+﻿using System.Text.RegularExpressions;
+using System.Xml.Linq;
 
 namespace OrangeHRMTest.Pages
 {
@@ -85,7 +86,7 @@ namespace OrangeHRMTest.Pages
                     { "61", new string[] { "59", "Employee Timesheets", "", "Select Employee" } },
                 { "62", new string[] { "58", "Attendance " } },
                     { "63", new string[] { "62", "My Records", "h5", "My Attendance Records" } },
-                    { "64", new string[] { "62", "Punch In/Out", "", "Punch (In|Out)" } },
+                    { "64", new string[] { "62", "Punch In/Out", "", "/Punch (In|Out)/" } },
                     { "65", new string[] { "62", "Employee Records", "h5", "Employee Attendance Records" } },
                     { "66", new string[] { "62", "Configuration", "", "Attendance Configuration" } },
                 { "67", new string[] { "58", "Reports " } },
@@ -152,8 +153,15 @@ namespace OrangeHRMTest.Pages
             if (allElements.ContainsKey(subelementId) && allElements[subelementId].Length == 4)
             {
                 string[] details = allElements[subelementId];
-                //returnValue = $"{(details[2] == "" ? "h6" : details[2])}.oxd-text:has-text('{(details[3] == "" ? details[1] : details[3])}')";
-                returnValue = $"{(details[2] == "" ? "h6" : details[2])}.oxd-text:text-matches('{(details[3] == "" ? details[1] : details[3])}')";
+                Regex isRegex = new Regex("^/(.*)/$");
+                if (isRegex.IsMatch(details[3]))
+                {
+                    returnValue = $"{(details[2] == "" ? "h6" : details[2])}.oxd-text:text-matches('{isRegex.Replace(details[3], "$1")}')";
+                }
+                else
+                {
+                    returnValue = $"{(details[2] == "" ? "h6" : details[2])}.oxd-text:has-text('{(details[3] == "" ? details[1] : details[3])}')";
+                }
             }
             return returnValue;
         }

--- a/Pages/AllPageTree.cs
+++ b/Pages/AllPageTree.cs
@@ -85,7 +85,7 @@ namespace OrangeHRMTest.Pages
                     { "61", new string[] { "59", "Employee Timesheets", "", "Select Employee" } },
                 { "62", new string[] { "58", "Attendance " } },
                     { "63", new string[] { "62", "My Records", "h5", "My Attendance Records" } },
-                    { "64", new string[] { "62", "Punch In/Out", "", "Punch In" } },
+                    { "64", new string[] { "62", "Punch In/Out", "", "Punch (In|Out)" } },
                     { "65", new string[] { "62", "Employee Records", "h5", "Employee Attendance Records" } },
                     { "66", new string[] { "62", "Configuration", "", "Attendance Configuration" } },
                 { "67", new string[] { "58", "Reports " } },
@@ -152,7 +152,8 @@ namespace OrangeHRMTest.Pages
             if (allElements.ContainsKey(subelementId) && allElements[subelementId].Length == 4)
             {
                 string[] details = allElements[subelementId];
-                returnValue = $"{(details[2] == "" ? "h6" : details[2])}.oxd-text:has-text('{(details[3] == "" ? details[1] : details[3])}')";
+                //returnValue = $"{(details[2] == "" ? "h6" : details[2])}.oxd-text:has-text('{(details[3] == "" ? details[1] : details[3])}')";
+                returnValue = $"{(details[2] == "" ? "h6" : details[2])}.oxd-text:text-matches('{(details[3] == "" ? details[1] : details[3])}')";
             }
             return returnValue;
         }

--- a/Pages/AllPageTree.cs
+++ b/Pages/AllPageTree.cs
@@ -20,7 +20,7 @@ namespace OrangeHRMTest.Pages
         //     1st element is the parent node's id
         //     2nd element is the node's name
         //     3rd element is the type of heading. If it is "" then "h6" is used
-        //     4th element is the heading text. If it is "" then the node's name is used
+        //     4th element is the heading text. If it is "" then the node's name is used. If it's of the form "/.../" it's treated as a regular expression
         public static Dictionary<string, string[]> allElements = new Dictionary<string, string[]>() {
             { "01", new string[] { "00", "Admin" } },
                 { "02", new string[] { "01", "User Management " } },

--- a/Pages/AllPageTree.cs
+++ b/Pages/AllPageTree.cs
@@ -1,5 +1,4 @@
 ﻿using System.Text.RegularExpressions;
-using System.Xml.Linq;
 
 namespace OrangeHRMTest.Pages
 {

--- a/Tests/AllPageTreeTests.cs
+++ b/Tests/AllPageTreeTests.cs
@@ -90,6 +90,7 @@ namespace OrangeHRMTest.Tests
 
         public async Task TestElementPageVisible2(string screen, string element)
         {
+            Regex isRegex = new Regex("^/(.*)/$");
             _navigationPanelPage = new NavigationPanelPage(_page);
             await _navigationPanelPage.GoToPageAsync(screen);
 
@@ -137,11 +138,17 @@ namespace OrangeHRMTest.Tests
                             // Get the text on the element page header
                             var headerText = await _AllPageTree.GetSublementPageHeaderText(subelementId);
                             Console.WriteLine($"Actual Header Text: {headerText}");
-                            //string expected = AllPageTree.allElements[subelementId][3] == "" ? subelement : AllPageTree.allElements[subelementId][3];
-                            //Assert.AreEqual(expected, headerText, false, $"The header {expected} was not found.");
-                            string expectedPattern = AllPageTree.allElements[subelementId][3] == "" ? subelement : AllPageTree.allElements[subelementId][3];
-                            Regex expectedRegex = new Regex(expectedPattern);
-                            StringAssert.Matches(headerText, expectedRegex, $"The header did not match the expected pattern {expectedPattern}");
+                            if (isRegex.IsMatch(AllPageTree.allElements[subelementId][3]))
+                            {
+                                string expectedPattern = isRegex.Replace(AllPageTree.allElements[subelementId][3], "$1");
+                                Regex expectedRegex = new Regex(expectedPattern);
+                                StringAssert.Matches(headerText, expectedRegex, $"The header did not match the expected pattern {expectedPattern}");
+                            }
+                            else
+                            {
+                                string expected = AllPageTree.allElements[subelementId][3] == "" ? subelement : AllPageTree.allElements[subelementId][3];
+                                Assert.AreEqual(expected, headerText, false, $"The header {expected} was not found.");
+                            }
 
                             // Perform verifications or interactions on the element page
                             bool isElementPageVisible = await _AllPageTree.IsElementPageVisibleAsync(elementId);
@@ -165,6 +172,7 @@ namespace OrangeHRMTest.Tests
 
         public async Task TestElementPageVisible3()
         {
+            Regex isRegex = new Regex("^/(.*)/$");
             _navigationPanelPage = new NavigationPanelPage(_page);
                 
             // Create a AllPage object
@@ -214,11 +222,17 @@ namespace OrangeHRMTest.Tests
                             // Get the text on the element page header
                             var headerText = await _AllPageTree.GetSublementPageHeaderText(subelementId);
                             Console.WriteLine($"        Actual header text: {headerText}");
-                            //string expected = AllPageTree.allElements[subelementId][3] == "" ? subelement : AllPageTree.allElements[subelementId][3];
-                            //Assert.AreEqual(expected, headerText, false, $"The header {expected} was not found.");
-                            string expectedPattern = AllPageTree.allElements[subelementId][3] == "" ? subelement : AllPageTree.allElements[subelementId][3];
-                            Regex expectedRegex = new Regex(expectedPattern);
-                            StringAssert.Matches(headerText, expectedRegex, $"The header did not match the expected pattern {expectedPattern}");
+                            if (isRegex.IsMatch(AllPageTree.allElements[subelementId][3]))
+                            {
+                                string expectedPattern = isRegex.Replace(AllPageTree.allElements[subelementId][3], "$1");
+                                Regex expectedRegex = new Regex(expectedPattern);
+                                StringAssert.Matches(headerText, expectedRegex, $"The header did not match the expected pattern {expectedPattern}");
+                            }
+                            else
+                            {
+                                string expected = AllPageTree.allElements[subelementId][3] == "" ? subelement : AllPageTree.allElements[subelementId][3];
+                                Assert.AreEqual(expected, headerText, false, $"The header {expected} was not found.");
+                            }
 
                             // Perform verifications or interactions on the element page
                             bool isElementPageVisible = await _AllPageTree.IsElementPageVisibleAsync(elementId);

--- a/Tests/AllPageTreeTests.cs
+++ b/Tests/AllPageTreeTests.cs
@@ -1,4 +1,6 @@
-﻿namespace OrangeHRMTest.Tests
+﻿using System.Text.RegularExpressions;
+
+namespace OrangeHRMTest.Tests
 {
     [TestClass]
     public class AllPageTreeTests
@@ -135,8 +137,11 @@
                             // Get the text on the element page header
                             var headerText = await _AllPageTree.GetSublementPageHeaderText(subelementId);
                             Console.WriteLine($"Actual Header Text: {headerText}");
-                            string expected = AllPageTree.allElements[subelementId][3] == "" ? subelement : AllPageTree.allElements[subelementId][3];
-                            Assert.AreEqual(expected, headerText, false, $"The header {expected} was not found.");
+                            //string expected = AllPageTree.allElements[subelementId][3] == "" ? subelement : AllPageTree.allElements[subelementId][3];
+                            //Assert.AreEqual(expected, headerText, false, $"The header {expected} was not found.");
+                            string expectedPattern = AllPageTree.allElements[subelementId][3] == "" ? subelement : AllPageTree.allElements[subelementId][3];
+                            Regex expectedRegex = new Regex(expectedPattern);
+                            StringAssert.Matches(headerText, expectedRegex, $"The header did not match the expected pattern {expectedPattern}");
 
                             // Perform verifications or interactions on the element page
                             bool isElementPageVisible = await _AllPageTree.IsElementPageVisibleAsync(elementId);
@@ -209,8 +214,11 @@
                             // Get the text on the element page header
                             var headerText = await _AllPageTree.GetSublementPageHeaderText(subelementId);
                             Console.WriteLine($"        Actual header text: {headerText}");
-                            string expected = AllPageTree.allElements[subelementId][3] == "" ? subelement : AllPageTree.allElements[subelementId][3];
-                            Assert.AreEqual(expected, headerText, false, $"The header {expected} was not found");
+                            //string expected = AllPageTree.allElements[subelementId][3] == "" ? subelement : AllPageTree.allElements[subelementId][3];
+                            //Assert.AreEqual(expected, headerText, false, $"The header {expected} was not found.");
+                            string expectedPattern = AllPageTree.allElements[subelementId][3] == "" ? subelement : AllPageTree.allElements[subelementId][3];
+                            Regex expectedRegex = new Regex(expectedPattern);
+                            StringAssert.Matches(headerText, expectedRegex, $"The header did not match the expected pattern {expectedPattern}");
 
                             // Perform verifications or interactions on the element page
                             bool isElementPageVisible = await _AllPageTree.IsElementPageVisibleAsync(elementId);

--- a/Tests/DashboardPageTests.cs
+++ b/Tests/DashboardPageTests.cs
@@ -48,14 +48,14 @@
         }
 
         [TestMethod]
-        [TestCategory("Ignore")]
+        [Ignore]
         public async Task TestSystemUsersFunctionality1()
         {
             // Your test steps for a specific functionality on the SystemUsers page
         }
 
         [TestMethod]
-        [TestCategory("Ignore")]
+        [Ignore]
         public async Task TestSystemUsersFunctionality2()
         {
             // Your test steps for another functionality on the SystemUsers page


### PR DESCRIPTION
This is to deal with the Time > Attendance > Punch In/Out screen which can either have a heading of "Punch In" or "Punch Out". Now the heading has to match the regular expression "Punch (In|Out)".